### PR TITLE
Reading extra missions

### DIFF
--- a/Ferret/CosmicExploration/WKSMission.lua
+++ b/Ferret/CosmicExploration/WKSMission.lua
@@ -69,6 +69,7 @@ function WKSMission:get_available_missions()
 
     repeat
         local mission = self:get_mission_name_by_index(index):gsub(" ", "")
+        yield("/echo "..mission)
         if mission ~= "" then
             local found_mission =
                 self.ferret.cosmic_exploration.mission_list:find_by_name(mission)
@@ -80,7 +81,7 @@ function WKSMission:get_available_missions()
             end
             index = index + 1
         end
-    until (mission == "")
+    until (mission == "" or mission  == "???")
 
     return missions
 end

--- a/Ferret/CosmicExploration/WKSMission.lua
+++ b/Ferret/CosmicExploration/WKSMission.lua
@@ -80,7 +80,7 @@ function WKSMission:get_available_missions()
             end
             index = index + 1
         end
-    until (mission == "" or mission == "???")
+    until (mission == "") or index >= 24
 
     return missions
 end

--- a/Ferret/CosmicExploration/WKSMission.lua
+++ b/Ferret/CosmicExploration/WKSMission.lua
@@ -69,7 +69,6 @@ function WKSMission:get_available_missions()
 
     repeat
         local mission = self:get_mission_name_by_index(index):gsub(" ", "")
-        yield("/echo "..mission)
         if mission ~= "" then
             local found_mission =
                 self.ferret.cosmic_exploration.mission_list:find_by_name(mission)
@@ -81,7 +80,7 @@ function WKSMission:get_available_missions()
             end
             index = index + 1
         end
-    until (mission == "" or mission  == "???")
+    until (mission == "" or mission == "???")
 
     return missions
 end


### PR DESCRIPTION
*Moved the code to another branch, so the previous PR got automatically closed :(

`GetNodeText` for the missions only goes from indexes 2 to 23. Beyond that that it starts highlighting the "Class A/B/C/D Missions" headers.

Starting node 24, there are only 4 child nodes, so `GetNodeText` on 8 will just return 8, hence the attempt to index a number value error.

![image](https://github.com/user-attachments/assets/769729d0-efef-42a0-9cf6-48aeca4b7d03)
