### PR TITLE
fix(RelicAutomator): handle mission with `CraftingMissionHandler`

### DIFF
--- a/lib/Ferret/Templates/CosmicExploration/RelicAutomator.lua
+++ b/lib/Ferret/Templates/CosmicExploration/RelicAutomator.lua
@@ -102,7 +102,7 @@ function RelicAutomator:loop()
     local goal = CosmicExploration:get_target_result(mission)
     Logger:info('Mission target: ' .. MissionResult.to_string(goal))
 
-    local result, reason = mission:handle(goal)
+    local result, reason = CraftingMissionHandler:handle(mission, goal)
     local acceptable = CosmicExploration:get_acceptable_result(mission)
 
     Logger:debug('Result: ' .. tostring(result))


### PR DESCRIPTION
With the introduction of `CraftingMissionHandler` and `GatheringMissionHandler`, the `Mission#handle` method got removed, and `RelicAutomator` was still using that instead of the appropriate Mission Handler, which this PR fixes.